### PR TITLE
SVG charts automatically update to total number of puzzles

### DIFF
--- a/puzzles/context.py
+++ b/puzzles/context.py
@@ -198,6 +198,9 @@ class Context:
     def all_puzzles(self):
         return tuple(models.Puzzle.objects.prefetch_related('metas').order_by('deep'))
 
+    def num_puzzles(self):
+        return len(self.all_puzzles)
+
     def unclaimed_hints(self):
         return models.Hint.objects.filter(status=models.Hint.NO_RESPONSE, claimer='').count()
 

--- a/puzzles/templates/finishers.html
+++ b/puzzles/templates/finishers.html
@@ -77,7 +77,7 @@ td {
     {% endif %}
     <tr>
         <td colspan="5">
-            <svg class="chart" viewbox="0 0 {{ team.hunt_length }} 41" preserveAspectRatio="none">
+            <svg class="chart" viewbox="0 0 {{ team.hunt_length }} {{ num_puzzles }}" preserveAspectRatio="none">
                 <path d="M {{ team.hunt_length }} 0 L 0 0
                 {% for solve in team.solves %}
                 L {{ solve.before }} {{ forloop.counter }}
@@ -85,7 +85,7 @@ td {
                 {% endfor %}
                 " class="area"></path>
                 {% for meta in team.metas %}
-                <path d="M {{ meta }} 0 L {{ meta }} 41" class="bar"></path>
+                <path d="M {{ meta }} 0 L {{ meta }} {{ num_puzzles }}" class="bar"></path>
                 {% endfor %}
             </svg>
         </td>

--- a/puzzles/templates/team.html
+++ b/puzzles/templates/team.html
@@ -107,8 +107,8 @@
     </div>
     {% if submissions|length %}
     {% if view_info_available or hunt_is_over %}
-    <svg class="chart" viewbox="0 0 {{ chart.hunt_length }} 41" preserveAspectRatio="none">
-        <path d="M 0 0 L {{ chart.end }} 0 L {{ chart.end }} 41 L 0 41" class="baz"></path>
+    <svg class="chart" viewbox="0 0 {{ chart.hunt_length }} {{ num_puzzles }}" preserveAspectRatio="none">
+        <path d="M 0 0 L {{ chart.end }} 0 L {{ chart.end }} {{ num_puzzles }} L 0 {{ num_puzzles }}" class="baz"></path>
         <path d="M {{ chart.hunt_length }} 0 L 0 0
         {% for solve in chart.solves %}
         L {{ solve.before }} {{ forloop.counter }}
@@ -116,7 +116,7 @@
         {% endfor %}
         " class="area"></path>
         {% for meta in chart.metas %}
-        <path d="M {{ meta }} 0 L {{ meta }} 41" class="bar"></path>
+        <path d="M {{ meta }} 0 L {{ meta }} {{ num_puzzles }}" class="bar"></path>
         {% endfor %}
     </svg>
     <table class="sortable gph-list-table">


### PR DESCRIPTION
When running hunt20, I noticed that the SVG charts generated in /team/X and /finishers didn't scale with the total number of puzzles. 