### PR TITLE
add tests on hint.answered_datetime

### DIFF
--- a/puzzles/templates/hint.html
+++ b/puzzles/templates/hint.html
@@ -41,8 +41,10 @@
             </td>
             <td colspan="3">
                 {{ hint.get_status_display }}
+                {% if hint.answered_datetime %}
                 {% format_time_since hint.answered_datetime now %}
                 ago by {{ hint.claimer }}
+                {% endif %}
             </td>
         </tr>
         <tr>
@@ -145,8 +147,10 @@
             <td>
                 <a href="{% url 'hint' hint.id %}">
                     {{ hint.get_status_display }}
+                    {% if hint.answered_datetime %}
                     {% format_time_since hint.answered_datetime now %}
                     ago by {{ hint.claimer }}
+                    {% endif %}
                 </a>
             </td>
             <td>


### PR DESCRIPTION
If an admin leaves the answered date as empty when acting on a hint in the admin interface (e.g. by refunding it), looking at the hint page at the next interaction (e.g. answering the hint from the discord link) will cause the page to crash because there's no test on hint.answered_datetime in a couple of places before calculating the time since it was answered.

Steps to reproduce:
- user asks for a hint
- admin refunds it in the admin interface (not the front end) but leaves the answered time empty
- users asks for a hint again
- admin looks at it on the front end (e.g. follows link from discord): page crashes in format_time_since (templatetags/puzzle_tags.py) because the timestamp is None

Fix is to add a couple of tests on hint.answered_datetime in templates/hint.html, as it was done in other places in the code.