### PR TITLE
Link to Heroku fork from DEPLOY.md.

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -4,6 +4,66 @@
 
 (This doc has not been updated for 2021.)
 
+## Heroku
+
+Heroku is a hosting "platform as a service". Heroku scales up and down to different amounts of compute power quite well and all costs are pro-rated (albeit by how long your app is set to that scale, not how much actual compute gets used).
+
+Follow instructions on the Heroku website to install the Heroku CLI and then create an app. Mine is called `gph-site-test`. Then, clone this repository and run `heroku git:remote -a gph-site-test`.
+
+Heroku requires some configuration/code changes, which exist on a [fork of the repo](https://github.com/jenna-h/gph-site-heroku). It's not essential that you understand this list, but they will probably be helpful for debugging:
+
+- We need a `Procfile` to tell Heroku how to run our app.
+- [SQLite isn't a good fit for Heroku](https://devcenter.heroku.com/articles/sqlite3) because Heroku doesn't provide a "real" filesystem. Fortunately Heroku provides easy-to-use (and free at low volumes) PostgreSQL, so we need to switch Django to use that instead. **Note** that running the Heroku-compatible website will be a bit harder because you need to get PostgreSQL running locally too. (It might be OK to switch the database only in the `prod` settings file, but we haven't set that up and `manage.py` still uses `dev` which means trying to running `manage.py` stuff on your prod server will not work. TODO: investigate if this is OK)
+- We install the `whitenoise` middleware so Django can serve static files directly in a production-ready way.
+
+**Make sure to `heroku config:set SECRET_KEY="YOUR_SECRET_KEY_HERE"`** to a securely generated long random string. Your app will still run if you don't do this step, but it will be insecure!
+
+In theory, if you now visit `yourappname.herokuapp.com` you should see the properly styled front page of the puzzlehunt website with some text about a puzzlehunt. (Heroku will automatically run `collectstatic` for you.) However, dynamic pages like Teams and Puzzles will show an error. You will still need to set up the database by running `heroku run python manage.py migrate` manually, or you can [add it to the Procfile to run automatically on every release](https://help.heroku.com/GDQ74SU2/django-migrations):
+
+```
+release: python manage.py migrate
+```
+
+### Running the Heroku version locally
+
+It's a bit more work to run the Heroku version locally because you'll need to Bring Your Own [PostgreSQL](https://www.postgresql.org/) Database. (As mentioned above, if you don't want to go through this hassle and are feeling adventurous, you could also change the settings modules to use SQLite locally and Heroku's database only on prod, and I've done it in the past, but it's pretty sketchy and I cannot recommend or provide support for it.)
+
+#### One-time setup
+
+You'll need to acquire [PostgreSQL](https://www.postgresql.org/) somehow (depending on your operating system) and make sure the server is running. [Heroku](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup) has some docs.
+
+You might need to create a Postgres user; it will be slightly easier for future tinkering if the username here is the same as your user account, but it doesn't have to be. You'll also want to create a Postgres database. To do those things, run `psql` as some user that already has an account and has create database permissions, most likely `postgres`. On Linux this is:
+
+```
+sudo -u postgres psql
+```
+
+Enter whichever of these two SQL commands you need into the `psql` prompt to create a new user with a password and a database. Fill in the values you want.
+
+```
+CREATE USER yourusername PASSWORD 'yourpassword';
+CREATE DATABASE yourdbname;
+```
+
+Unless you've done something funky to explicitly allow other people to connect to your PostgreSQL server, this is only usable for local development and the password will be lying around in plaintext on your computer anyway, so the password doesn't have to be secure. But I haven't figured out how to not use one and have it work with later steps. After typing that and hitting Enter, if it worked, you can quit `psql` (maybe Ctrl-D).
+
+Back in the `gph-site` directory, create a file called `.env` with these two lines, except in `DATABASE_URL`, replace the username, password, and database name with whatever you used above.
+
+```
+DATABASE_URL=postgres://yourusername:yourpassword@127.0.0.1:5432/yourdbname
+DJANGO_SETTINGS_MODULE=gph.settings.dev
+```
+
+If you don't set the settings module, your local website might try to actually send emails or Discord notifications and such.
+
+#### Every time
+
+You'll always need to make sure the PostgreSQL server is running before trying to run the server.
+
+To set up other things (creating superusers, migrating or making migrations, loading data), you can mostly follow instructions in `README.md`, except that when asked to run `./manage.py something` you should instead run `heroku local:run ./manage.py something`. There is also one additional step because of Heroku's extra handling around static files: the first time you're running the website locally or any time you change the static assets, run `./manage.py collectstatic`.
+
+After everything else is ready, to run the website, just run `heroku local`.
+
 ## PythonAnywhere
 
 PythonAnywhere is a Python hosting service that has a reasonably powerful free tier, and is overall pretty beginner-friendly, but if you do know your way around computers you might have a bit more trouble. (For example, being able to SSH from your own computer appears to be a paid feature.) The instructions below are mostly cribbed from:
@@ -78,65 +138,3 @@ python manage.py migrate
 If you want to create a user you can use to log in to the website and administer the hunt, run `python manage.py createsuperuser` in the terminal and follow instructions. There are also configurations that (currently) cannot be made directly through the website, which are generally in `hunt_config.py`.
 
 **IMPORTANT: Set the SECRET_KEY in `settings/base.py`** to a securely generated long random string. Your app will still run if you don't do this step, but it will be insecure!
-
-## Heroku
-
-Heroku is another hosting "platform as a service" with a free tier. The free tier is serviceable, but Heroku scales up and down to different amounts of compute power quite well and all costs are pro-rated (albeit by how long your app is set to that scale, not how much actual compute gets used).
-
-Follow instructions on the Heroku website to install the Heroku CLI and then create an app. Mine is called `gph-site-test`. Then, clone this repository and run `heroku git:remote -a gph-site-test`.
-
-Heroku requires some configuration/code changes, which are on a separate branch `heroku` of this repo. It's not essential that you understand this list, but they will probably be helpful for debugging:
-
-- We need a `Procfile` to tell Heroku how to run our app.
-- [SQLite isn't a good fit for Heroku](https://devcenter.heroku.com/articles/sqlite3) because Heroku doesn't provide a "real" filesystem. Fortunately Heroku provides easy-to-use (and free at low volumes) PostgreSQL, so we need to switch Django to use that instead. **Note** that running the website from the Heroku branch will be a bit harder because you need to get PostgreSQL running locally too. (It might be OK to switch the database only in the `prod` settings file, but we haven't set that up and `manage.py` still uses `dev` which means trying to running `manage.py` stuff on your prod server will not work. TODO: investigate if this is OK)
-- We install the `whitenoise` middleware so Django can serve static files directly in a production-ready way.
-
-If you run `git push heroku heroku:master`, you will push the `heroku` branch to its `master` and deploy the code.
-
-**Make sure to `heroku config:set SECRET_KEY="YOUR_SECRET_KEY_HERE"`** to a securely generated long random string. Your app will still run if you don't do this step, but it will be insecure!
-
-In theory, if you now visit `yourappname.herokuapp.com` you should see the properly styled front page of the puzzlehunt website with some text about a puzzlehunt. (Heroku will automatically run `collectstatic` for you.) However, dynamic pages like Teams and Puzzles will show an error. You will still need to set up the database by running `heroku run python manage.py migrate` manually, or you can [add it to the Procfile to run automatically on every release](https://help.heroku.com/GDQ74SU2/django-migrations):
-
-```
-release: python manage.py migrate
-```
-
-### Running the Heroku version locally
-
-It's a bit more work to run the Heroku version locally because you'll need to Bring Your Own [PostgreSQL](https://www.postgresql.org/) Database. (As mentioned above, if you don't want to go through this hassle and are feeling adventurous, you could also change the settings modules to use SQLite locally and Heroku's database only on prod, and I've done it in the past, but it's pretty sketchy and I cannot recommend or provide support for it.)
-
-#### One-time setup
-
-You'll need to acquire [PostgreSQL](https://www.postgresql.org/) somehow (depending on your operating system) and make sure the server is running. [Heroku](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup) has some docs.
-
-You might need to create a Postgres user; it will be slightly easier for future tinkering if the username here is the same as your user account, but it doesn't have to be. You'll also want to create a Postgres database. To do those things, run `psql` as some user that already has an account and has create database permissions, most likely `postgres`. On Linux this is:
-
-```
-sudo -u postgres psql
-```
-
-Enter whichever of these two SQL commands you need into the `psql` prompt to create a new user with a password and a database. Fill in the values you want.
-
-```
-CREATE USER yourusername PASSWORD 'yourpassword';
-CREATE DATABASE yourdbname;
-```
-
-Unless you've done something funky to explicitly allow other people to connect to your PostgreSQL server, this is only usable for local development and the password will be lying around in plaintext on your computer anyway, so the password doesn't have to be secure. But I haven't figured out how to not use one and have it work with later steps. After typing that and hitting Enter, if it worked, you can quit `psql` (maybe Ctrl-D).
-
-Back in the `gph-site` directory, create a file called `.env` with these two lines, except in `DATABASE_URL`, replace the username, password, and database name with whatever you used above.
-
-```
-DATABASE_URL=postgres://yourusername:yourpassword@127.0.0.1:5432/yourdbname
-DJANGO_SETTINGS_MODULE=gph.settings.dev
-```
-
-If you don't set the settings module, your local website might try to actually send emails or Discord notifications and such.
-
-#### Every time
-
-You'll always need to make sure the PostgreSQL server is running before trying to run the server.
-
-To set up other things (creating superusers, migrating or making migrations, loading data), you can mostly follow instructions in `README.md`, except that when asked to run `./manage.py something` you should instead run `heroku local:run ./manage.py something`. There is also one additional step because of Heroku's extra handling around static files: the first time you're running the website locally or any time you change the static assets, run `./manage.py collectstatic`.
-
-After everything else is ready, to run the website, just run `heroku local`.


### PR DESCRIPTION
It seems there used to be a "heroku" branch of gph-site, but it doesn't exist any more.

I made a [fork of gph-site with the Heroku changes included](https://github.com/jenna-h/gph-site-heroku) and updated DEPLOY.md accordingly.

I also moved the Heroku section of DEPLOY.md to the front, since I think it's probably a better solution than PythonAnywhere (I recently heard someone was having some problems getting gph-site to run with it).