### PR TITLE
FIX: fix logging path for dev

### DIFF
--- a/gph/settings/dev.py
+++ b/gph/settings/dev.py
@@ -45,25 +45,25 @@ LOGGING = {
         'django': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': './logs/django.log',
+            'filename': os.path.join(LOGS_DIR, 'django.log'),
             'formatter': 'django-file',
         },
         'general': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': './logs/general.log',
+            'filename': os.path.join(LOGS_DIR, 'general.log'),
             'formatter': 'puzzles-file',
         },
         'puzzle': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': './logs/puzzle.log',
+            'filename': os.path.join(LOGS_DIR, 'puzzle.log'),
             'formatter': 'puzzles-file',
         },
         'request': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': './logs/request.log',
+            'filename': os.path.join(LOGS_DIR, 'request.log'),
             'formatter': 'puzzles-file',
         },
         'django-console': {


### PR DESCRIPTION
This PR changes the paths for logging files listed in `gph/settings/dev.py` from relative paths such as `./logs/django.log` to paths constructed with `os.path.join` and the `LOGS_DIR` variable (as in `base.py`).  The current version treats the `.` as the current working directory; this is usually fine in local development, when it's assumed that you'll be running `./manage.py whatever` from the project root, but will break when that doesn't hold.  (One example is when developing on PythonAnywhere; it's possible to set the working directory to the project root, but that's not the default.)