### PR TITLE
By default, numbers should not be telephone numbers.

### DIFF
--- a/puzzles/templates/base.html
+++ b/puzzles/templates/base.html
@@ -7,6 +7,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="format-detection" content="telephone=no">
     {% block page-title %}
     <title>{{ hunt_title }}</title>
     {% endblock %}


### PR DESCRIPTION
The [Apple Developer Documentation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html) states: "By default, Safari on iOS detects any string formatted like a phone number and makes it a link that calls the number."

This is disruptive to puzzle formatting.

Telephone links are still possible with the explicit use of the "tel" URI scheme.

See https://stackoverflow.com/a/227238