### PR TITLE
Wrap the puzzle list in a table, as intended

### DIFF
--- a/puzzles/templates/round.html
+++ b/puzzles/templates/round.html
@@ -26,6 +26,8 @@
 <p style="text-align: center">{% translate "Imagine some cool art goes here." %}</p>
 {% endblock %}
 
+<table class="puzzles-list">
 {% include 'puzzles_list.html' with round=round %}
+</table>
 
 {% endblock %}


### PR DESCRIPTION
`puzzles_list.html` provides a `<tbody>`, so it should be a child of a `<table>` element, as can be seen in `puzzles.html`. Without the wrapping `<table>` the formatting is poor.