### PR TITLE
Make unix_time more portable

### DIFF
--- a/puzzles/templatetags/puzzle_tags.py
+++ b/puzzles/templatetags/puzzle_tags.py
@@ -42,7 +42,7 @@ def days_between(before, after):
 
 @register.filter
 def unix_time(timestamp):
-    return timestamp.strftime('%s') if timestamp else ''
+    return timestamp.timestamp() if timestamp else ''
 
 @register.simple_tag
 def format_time(timestamp, format='DATE_TIME'):


### PR DESCRIPTION
strftime('%s') is platform dependent, and does not work on Windows. This has the net effect that team pages of teams that have solves will crash if accessed, if the server is running on a Windows machine.

To get the Unix timestamp it is better to use timestamp(). It appears that this is only really used for values for sorting so minor differences (e.g. showing/not showing milliseconds) should not be a big deal.

Also see: https://stackoverflow.com/questions/11743019/convert-python-datetime-to-epoch-with-strftime